### PR TITLE
Merge v2.0.0 of MobileChromeApps/zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ A Cordova plugin to unzip files in Android and iOS.
 
 ##Usage
 
-        zip.unzip('full file path', 'directory to extract into', function(){
-            console.log('All done');
-        });
+    zip.unzip(<source zip>, <destination dir>, <callback>);
+
+Both source and destination arguments can be URLs obtained from the HTML File
+interface or absolute paths to files on the device.
+
+The callback argument will be executed when the unzip is complete, or when an
+error occurs. It will be called with a single argument, which will be 0 on
+success, or -1 on failure.

--- a/plugin.xml
+++ b/plugin.xml
@@ -4,7 +4,7 @@
     id="org.chromium.zip"
     version="1.0.0">
   <engines>
-    <engine name="cordova" version=">=3.0.0" />
+    <engine name="cordova" version=">=3.3.0" />
   </engines>
 
   <name>Zip</name>

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,12 +2,13 @@
 <plugin xmlns="http://phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="org.chromium.zip"
-    version="1.0.0">
+    version="2.0.0">
   <engines>
     <engine name="cordova" version=">=3.3.0" />
   </engines>
 
   <name>Zip</name>
+  <dependency id="org.apache.cordova.file" version="1.0.1" />
 
   <js-module src="zip.js" name="Zip">
     <clobbers target="zip" />

--- a/src/android/Zip.java
+++ b/src/android/Zip.java
@@ -53,15 +53,14 @@ public class Zip extends CordovaPlugin {
             CordovaResourceApi resourceApi = webView.getResourceApi();
 
             File tempFile = resourceApi.mapUriToFile(zipUri);
-            boolean ex = tempFile.exists();
-            if(!ex) {
-                Log.e(LOG_TAG, "Doesn't exist");
+            if(tempFile == null || !tempFile.exists()) {
+                Log.e(LOG_TAG, "Zip file does not exist");
             }
 
             File outputDir = resourceApi.mapUriToFile(outputUri);
             outputDirectory = outputDir.getAbsolutePath();
             outputDirectory += outputDirectory.endsWith(File.separator) ? "" : File.separator;
-            if(!outputDir.exists() && !outputDir.mkdirs()){
+            if(outputDir == null || (!outputDir.exists() && !outputDir.mkdirs())){
                 throw new FileNotFoundException("File: \"" + outputDirectory + "\" not found");
             }
 

--- a/src/android/Zip.java
+++ b/src/android/Zip.java
@@ -99,6 +99,7 @@ public class Zip extends CordovaPlugin {
                    dir.mkdirs();
                 } else {
                     File file = new File(outputDirectory + compressedName);
+                    file.getParentFile().mkdirs();
                     if(file.exists() || file.createNewFile()){
                         FileOutputStream fout = new FileOutputStream(file);
                         int count;

--- a/src/ios/Zip.m
+++ b/src/ios/Zip.m
@@ -1,6 +1,24 @@
 #import "Zip.h"
+#import "CDVFile.h"
 
 @implementation Zip
+
+- (NSString *)pathForURL:(NSString *)urlString
+{
+    // Attempt to use the File plugin to resolve the destination argument to a
+    // file path.
+    NSString *path;
+    id filePlugin = [self.commandDelegate getCommandInstance:@"File"];
+    if (filePlugin != nil) {
+        CDVFilesystemURL* url = [CDVFilesystemURL fileSystemURLWithString:urlString];
+        path = [filePlugin filesystemPathForURL:url];
+    }
+    // If that didn't work for any reason, return the original argument.
+    if (path == nil) {
+        path = urlString;
+    }
+    return path;
+}
 
 - (void)unzip:(CDVInvokedUrlCommand*)command
 {
@@ -8,9 +26,13 @@
         CDVPluginResult* pluginResult = nil;
         
         @try {
-            NSString *zipPath = [command.arguments objectAtIndex:0] ;
-            NSString *destinationPath = [command.arguments objectAtIndex:1];
+            NSString *zipURL = [command.arguments objectAtIndex:0];
+            NSString *destinationURL = [command.arguments objectAtIndex:1];
             NSError *error;
+
+            NSString *zipPath = [self pathForURL:zipURL];
+            NSString *destinationPath = [self pathForURL:destinationURL];
+
             if([SSZipArchive unzipFileAtPath:zipPath toDestination:destinationPath overwrite:YES password:nil error:&error]) {
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
             } else {


### PR DESCRIPTION
The AEM mobile team is requesting that the cordova-zip-plugin be updated to v2.0.0 of the MobileChromeApps/zip plugin.  Among other fixes this merge fixes an error on Android when attempting to unzip a file to a directory that does not exist on the device yet.

See: https://github.com/arumsey/cordova-zip-plugin/compare/Adobe-Marketing-Cloud:master...master#diff-b62faa9df87e4c59a730f88d2307c3f3R109
